### PR TITLE
backport metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,86 +1,12 @@
 [build-system]
 requires = [
-    "setuptools>= 61.0.0",
-    "setuptools_scm[toml]>=7.0",
+    "setuptools>=45",
+    "setuptools_scm[toml]>=6.0",
 ]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "picotui"
-description = "A simple text user interface (TUI) library."
-dynamic = ["version"]
-readme = "README.rst"
-
-# legacy bits and new both fail in different versions
-# need workaround until PEP639 has more backend support
-# for now, use deprecated format for conda compatibility
-#license = "MIT"
-license = {"text" = "MIT"}
-
-authors = [
-    {name = "Paul Sokolovsky"},
-    {email = "pfalcon@users.sourceforge.net"},
-]
-maintainers = [
-    {name = "Stephen L Arnold", email = "stephen.arnold42@gmail.com"},
-]
-
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Intended Audience :: Developers",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Software Development :: Embedded Systems",
-]
-
-# dependencies = []
-
-requires-python = ">=3.6"
-
-[project.optional-dependencies]
-dev = [
-    "flake8",
-    "isort",
-    "mypy==0.990",
-    "black >= 22.3.0",
-    "pylint >= 3.1.0",
-]
-cov = [
-    "covdefaults",
-    "coverage[toml]",
-]
-doc = [
-    "sphinx",
-    "sphinx_git",
-    "sphinxcontrib.apidoc",
-    "myst-parser",
-    "sphinx_rtd_theme<3.0.0",
-]
-test = [
-    "pytest",
-    "pytest-cov",
-]
-
-[project.urls]
-Homepage = "https://github.com/pfalcon/picotui"
-Repository = "https://github.com/pfalcon/picotui.git"
-Issues = "https://github.com/pfalcon/picotui/issues"
-Changelog = "https://github.com/pfalcon/picotui/blob/master/CHANGELOG.rst"
-
-[tool.setuptools.packages.find]
-namespaces = true
-include = [
-    "picotui",
-]
-exclude = [
-    "docs/",
-    "tests/",
-]
-
 [tool.setuptools_scm]
+version_scheme = "post-release"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -89,6 +15,10 @@ log_cli =  true
 doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE",]
 addopts = "--strict-markers"
 markers = "subscript"
+filterwarnings = [
+    "ignore:currentThread:DeprecationWarning",
+    "ignore:co_lnotab:DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true
@@ -97,7 +27,7 @@ omit = [
     "examples/*",
     "tests/*",
     "setup.py",
-    ".tox",
+    ".tox/*",
 ]
 
 [tool.coverage.paths]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,79 @@
+[metadata]
+name = 
+version = attr: setuptools_scm.get_version
+description = A simple text user interface (TUI) library.
+url = https://github.com/sarnold/picotui
+author = Paul Sokolovsky
+author_email = pfalcon@users.sourceforge.net
+maintainer = Stephen Arnold
+maintainer_email = nerdboy@gentoo.org
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+license_expression = MIT
+license_files = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    Operating System :: POSIX :: Linux
+    Operating System :: Unix
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Embedded Systems
+
+project_urls =
+    Bug Reports = https://github.com/sarnold/picotui/issues
+    Source = https://github.com/sarnold/picotui.git
+
+[options]
+python_requires = >= 3.6
+
+setup_requires =
+    setuptools_scm[toml]
+
+install_requires =
+
+packages =
+    picotui
+
+# extra deps are included here mainly for local/venv installs using pip
+# otherwise deps are handled via tox, ci config files or pkg managers
+[options.extras_require]
+doc =
+    sphinx
+    sphinx_git
+    sphinx_rtd_theme<3.0
+    sphinxcontrib-apidoc
+    myst-parser
+test =
+    pytest
+    pytest-cov
+cov =
+    coverage[toml]
+    coverage_python_version
+all =
+    %(cov)s
+    %(doc)s
+    %(test)s
+
+[check]
+metadata = true
+restructuredtext = true
+strict = false
+
+[check-manifest]
+ignore =
+    .gitattributes
+    .gitignore
+    .pre-commit-config.yaml
+
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    docs,
+    tests
+
+max-line-length = 90

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 
 commands =
     #python -m unittest discover -s tests
-    coverage run --omit="tests/test_WListBox.py" -m unittest discover -s tests
+    coverage run --branch --omit="tests/test_WListBox.py,.tox/*" -m unittest discover -s tests
     #python -m pytest -v tests/ --capture={posargs:"no"} --doctest-modules '--doctest-glob=*.rst' '--doctest-glob=*.py'  --cov=picotui --cov-branch --cov-report term-missing
 
 [testenv:coverage]
@@ -75,7 +75,7 @@ allowlist_externals =
     bash
 
 deps =
-    coverage
+    coverage[toml]
 
 commands =
     bash -c 'coverage combine .coverage.py*'


### PR DESCRIPTION
* move metadata to setup.cfg from pyproject.toml
* required for el9 packaging macros